### PR TITLE
Remove  getSingleProduct

### DIFF
--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -30,16 +30,6 @@ export class ProductsService {
     }));
   }
 
-  async getSingleProduct(productId: string) {
-    const product = await this.findProduct(productId);
-    return {
-      id: product.id,
-      title: product.title,
-      description: product.description,
-      price: product.price,
-    };
-  }
-
   async updateProduct(
     productId: string,
     title: string,


### PR DESCRIPTION
As we now work with the database object, shouldn't we remove this function (getSingleProduct), as we don't use it anymore?